### PR TITLE
Refactor rate limiter for DI and improve testability

### DIFF
--- a/app/api/v1/dependencies/rate_limiter_dependency.py
+++ b/app/api/v1/dependencies/rate_limiter_dependency.py
@@ -2,16 +2,20 @@ from fastapi import Depends, HTTPException, Request
 from app.core.rate_limiter import RateLimiter
 import time
 
-# Initialize a shared rate limiter instance (e.g., 5 requests per 60 seconds)
-rate_limiter = RateLimiter(rate=5, time_window=60)
+# Default rate limiter instance
+def get_rate_limiter_instance():
+    return RateLimiter(rate=5, time_window=60)
 
-def get_rate_limiter(request: Request):
-    # IP-based limits utilizing request.client.host
-    # In real apps, use something like request.headers["X-API-Key"] or request.state.user_id 
-    customer_id = request.client.host
+def get_rate_limiter(
+    request: Request,
+    limiter: RateLimiter = Depends(get_rate_limiter_instance)
+):
+    # Use header-based customer ID for testability
+    customer_id = request.headers.get("X-Client-ID") or request.client.host
     
     current_time = time.time()
-    if not rate_limiter.is_allowed(customer_id, current_time):
+
+    if not limiter.is_allowed(customer_id, current_time):
         raise HTTPException(
             status_code=429,
             detail="Rate limit exceeded. Try again later."

--- a/poetry.lock
+++ b/poetry.lock
@@ -33,6 +33,17 @@ test = ["anyio[trio]", "blockbuster (>=1.5.23)", "coverage[toml] (>=7)", "except
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
+name = "certifi"
+version = "2025.6.15"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"},
+    {file = "certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"},
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 description = "Composable command line interface toolkit"
@@ -168,6 +179,27 @@ files = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 description = "A collection of framework independent HTTP protocol utils."
@@ -221,6 +253,30 @@ files = [
 
 [package.extras]
 test = ["Cython (>=0.29.24)"]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "idna"
@@ -863,4 +919,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.9"
-content-hash = "5f2f7c3d6cddbf0f6cb743e12bb57663208d80d9ddadb171f54a2a9f44c6b061"
+content-hash = "702f30beb9d7093a58288c0377b7247dc8e24c801b73cfb3c51f42a44da98623"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ fastapi = "^0.115.14"
 uvicorn = {extras = ["standard"], version = "^0.35.0"}
 pytest = "^8.4.1"
 pytest-cov = "^6.2.1"
+httpx = "^0.28.1"
 
 
 [build-system]

--- a/tests/test_api_ping.py
+++ b/tests/test_api_ping.py
@@ -1,0 +1,58 @@
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import status
+from app.main import app
+
+from app.api.v1.routes.resource import resource_router
+from app.core.rate_limiter import RateLimiter
+from app.api.v1.dependencies import rate_limiter_dependency
+import app.api.v1.dependencies.rate_limiter_dependency as rl_dep
+
+@pytest.fixture
+def test_rate_limiter():
+    return RateLimiter(rate=5, time_window=60)
+
+@pytest.fixture(autouse=True)
+def override_dependencies(test_rate_limiter):
+    app.dependency_overrides[
+        rate_limiter_dependency.get_rate_limiter_instance
+    ] = lambda: test_rate_limiter
+
+@pytest.fixture
+def client():
+    app.include_router(resource_router, prefix="/api/v1")
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides = {}
+
+class TestRateLimiterEndpoint:
+    def test_ping_allows_within_limit(self, client: TestClient):
+        response = client.get("/api/v1/ping")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"message": "pong"}
+
+    def test_ping_rejects_exceeding_limit(self, client: TestClient):
+        headers = {"X-Client-ID": "test-user"}
+        for _ in range(5):
+            client.get("/api/v1/ping", headers=headers)
+
+        response = client.get("/api/v1/ping", headers=headers)
+        assert response.status_code == 429
+        assert "Rate limit exceeded" in response.json()["detail"]
+
+    def test_ping_allows_in_new_window(self, client: TestClient, monkeypatch):
+        headers = {"X-Client-ID": "test-user"}
+
+        # Window 10s
+        monkeypatch.setattr(rl_dep.time, "time", lambda: 10)
+        for _ in range(5):
+            client.get("/api/v1/ping", headers=headers)
+
+        response = client.get("/api/v1/ping", headers=headers)
+        assert response.status_code == 429
+
+        # Window 70s
+        monkeypatch.setattr(rl_dep.time, "time", lambda: 70)
+        response = client.get("/api/v1/ping", headers=headers)
+        assert response.status_code == 200
+


### PR DESCRIPTION
- Inject RateLimiter via get_rate_limiter_instance
- Support X-Client-ID header for better test control
- Use monkeypatch to simulate time instead of sleep
- Override dependencies in tests for isolation